### PR TITLE
Add ca-certificates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN go get github.com/jsonnet-bundler/jsonnet-bundler/cmd/jb && \
 # Create image for dashboard generation
 FROM alpine:3.8 
 
-RUN apk add --no-cache libstdc++=6.4.0-r9 
+RUN apk add --no-cache libstdc++=6.4.0-r9 ca-certificates
 
 WORKDIR /dashboards
 


### PR DESCRIPTION
Some CI systems rely on ca-certificates to perform operations.

This image currently breaks with CircleCI

See: https://support.circleci.com/hc/en-us/articles/360016505753-Resolve-Certificate-Signed-By-Unknown-Authority-error-in-Alpine-images?flash_digest=39b76521a337cecacac0cc10cb28f3747bb5fc6a